### PR TITLE
Changed event type for select fields to support firefox

### DIFF
--- a/lib/bind.js
+++ b/lib/bind.js
@@ -282,6 +282,8 @@ var Bind = (function Bind(global) {
             var event = {
               checkbox: 'change',
               radio: 'change',
+              'select-one': 'change',
+              'select-multiple': 'change',
             }[element.type];
 
             element.addEventListener(event || 'input', oninput);


### PR DESCRIPTION
Per [mdn](https://developer.mozilla.org/en-US/docs/Web/Events/input) the input event should only be fired on input and textarea elements.
